### PR TITLE
Retry failed operation

### DIFF
--- a/src/lib/actions/report.actions.ts
+++ b/src/lib/actions/report.actions.ts
@@ -3,7 +3,7 @@
 import { createAdminClient } from '@/lib/appwrite';
 import { appwriteConfig } from '@/lib/appwrite/config';
 import { ID, Query } from 'node-appwrite';
-import { model } from '@/lib/ai/gemini';
+import { getModel } from '@/lib/ai/gemini';
 // Fluent Reports import removed - will be handled server-side only
 
 export interface GenerateReportData {
@@ -409,6 +409,7 @@ async function generateAIAnalysis(data: {
     `;
 
     console.log('Calling Gemini AI model...');
+    const model = getModel();
     const result = await model.generateContent(prompt);
     console.log('Got result from Gemini');
     const response = await result.response;

--- a/src/lib/ai-contract-analyzer.ts
+++ b/src/lib/ai-contract-analyzer.ts
@@ -35,7 +35,7 @@ export interface AIAnalysisRequest {
   analysisType?: 'comprehensive' | 'financial' | 'compliance' | 'risk';
 }
 
-import { model } from '@/lib/ai/gemini';
+import { getModel } from '@/lib/ai/gemini';
 import { SAMContract } from '@/lib/sam-config';
 
 export class ContractAnalyzer {


### PR DESCRIPTION
Make Gemini AI and Mailgun service initialization lazy to prevent build-time errors when API keys are not present.

---
<a href="https://cursor.com/background-agent?bcId=bc-89a7a252-32ca-475b-92c1-3849b195794f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89a7a252-32ca-475b-92c1-3849b195794f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

