### PR TITLE
Add leading space to name and email

### DIFF
--- a/src/app/(root)/dashboard/UserManagement.tsx
+++ b/src/app/(root)/dashboard/UserManagement.tsx
@@ -325,8 +325,11 @@ const UserManagement = () => {
               </label>
               <Input
                 name="fullName"
-                value={editForm.fullName}
-                onChange={handleEditChange}
+                value={editForm.fullName ? ` ${editForm.fullName.replace(/^ /, '')}` : ''}
+                onChange={(e) => {
+                  const value = e.target.value.replace(/^ /, '');
+                  setEditForm({ ...editForm, fullName: value });
+                }}
                 required
               />
             </div>

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -166,6 +166,11 @@ const AuthForm = ({ type }: { type: FormType }) => {
                       <Input
                         placeholder=" Enter your full name"
                         {...field}
+                        value={field.value ? ` ${field.value.replace(/^ /, '')}` : ''}
+                        onChange={(e) => {
+                          const value = e.target.value.replace(/^ /, '');
+                          field.onChange(value);
+                        }}
                         className="shad-input"
                       />
                     </FormControl>
@@ -186,6 +191,11 @@ const AuthForm = ({ type }: { type: FormType }) => {
                     <Input
                       placeholder=" Enter your email"
                       {...field}
+                      value={field.value ? ` ${field.value.replace(/^ /, '')}` : ''}
+                      onChange={(e) => {
+                        const value = e.target.value.replace(/^ /, '');
+                        field.onChange(value);
+                      }}
                       className="shad-input"
                     />
                   </FormControl>

--- a/src/components/settings/ProfileSettings.tsx
+++ b/src/components/settings/ProfileSettings.tsx
@@ -61,8 +61,11 @@ const ProfileSettings = () => {
           </Label>
           <Input
             id="fullName"
-            value={formData.fullName}
-            onChange={(e) => handleInputChange('fullName', e.target.value)}
+            value={formData.fullName ? ` ${formData.fullName.replace(/^ /, '')}` : ''}
+            onChange={(e) => {
+              const value = e.target.value.replace(/^ /, '');
+              handleInputChange('fullName', value);
+            }}
             className="mt-1"
           />
         </div>
@@ -74,8 +77,11 @@ const ProfileSettings = () => {
           <Input
             id="email"
             type="email"
-            value={formData.email}
-            onChange={(e) => handleInputChange('email', e.target.value)}
+            value={formData.email ? ` ${formData.email.replace(/^ /, '')}` : ''}
+            onChange={(e) => {
+              const value = e.target.value.replace(/^ /, '');
+              handleInputChange('email', value);
+            }}
             className="mt-1"
           />
         </div>


### PR DESCRIPTION
Add leading space padding to full name and email inputs for display, ensuring the actual stored value remains unpadded.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d682a7f-bce2-44e3-b67a-62ba0e809812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d682a7f-bce2-44e3-b67a-62ba0e809812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

