### PR TITLE
Style 2fa setup button and shield icon

### DIFF
--- a/src/components/TwoFactorModal.tsx
+++ b/src/components/TwoFactorModal.tsx
@@ -217,13 +217,13 @@ const TwoFactorModal = ({
               </div>
             </div>
 
-            <div className="flex gap-3 ">
+            <div className="flex gap-3 justify-center">
               <Button
                 onClick={setupTwoFactor}
                 className="primary-btn"
                 disabled={isLoading}
               >
-                <Shield className="h-4 w-4 mr-2 text-slate-700" />
+                <Shield className="h-4 w-4 mr-2" style={{ color: '#ffffff' }} />
                 {isLoading ? 'Setting up...' : 'Setup 2FA'}
               </Button>
             </div>


### PR DESCRIPTION
Center the "Setup 2FA" button and change the shield icon color to white to improve UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ec62030-fc8b-4ec7-b841-e27ea3042aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ec62030-fc8b-4ec7-b841-e27ea3042aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

