### PR TITLE
Add user profile picture to dashboard header

### DIFF
--- a/src/app/api/user/update/route.ts
+++ b/src/app/api/user/update/route.ts
@@ -4,7 +4,7 @@ import { updateUserProfile } from '@/lib/actions/user.actions';
 export async function PATCH(req: NextRequest) {
   try {
     const body = await req.json();
-    const { accountId, fullName, role, division } = body;
+    const { accountId, fullName, role, division, avatarUrl } = body;
     if (!accountId) {
       return NextResponse.json({ error: 'Missing accountId' }, { status: 400 });
     }
@@ -36,6 +36,7 @@ export async function PATCH(req: NextRequest) {
       fullName,
       role,
       division: divisionValue,
+      avatarUrl,
     });
     return NextResponse.json({ user: updatedUser });
   } catch (error) {

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { Bell, Mail, LogOut } from 'lucide-react';
+import { Bell, Mail, LogOut, Image as ImageIcon, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import NotificationCenter from '@/components/NotificationCenter';
 import NotificationBadge from '@/components/NotificationBadge';
@@ -10,6 +10,15 @@ import QuickActions from '@/components/QuickActions';
 import { Models } from 'appwrite';
 import { signOutUser } from '@/lib/actions/user.actions';
 import { getUnreadNotificationsCount } from '@/lib/actions/notification.actions';
+import Avatar from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useToast } from '@/hooks/use-toast';
+import { avatarPlaceholderUrl } from '../../constants';
 
 interface DashboardHeaderProps {
   user?:
@@ -25,6 +34,12 @@ const DashboardHeader = ({ user }: DashboardHeaderProps) => {
   const router = useRouter();
   const [notifOpen, setNotifOpen] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
+  const [isUploading, setIsUploading] = useState(false);
+  const [avatarUrl, setAvatarUrl] = useState<string | undefined>(
+    (user as any)?.prefs?.avatar || (user as any)?.avatar || undefined
+  );
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { toast } = useToast();
 
   const fetchUnread = useCallback(async () => {
     // Fetch unread notifications for the current user
@@ -62,6 +77,60 @@ const DashboardHeader = ({ user }: DashboardHeaderProps) => {
     }
   };
 
+  const openFilePicker = () => fileInputRef.current?.click();
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !user?.$id) return;
+    try {
+      setIsUploading(true);
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('userId', user.$id);
+      formData.append('department', '');
+      formData.append('uploadId', `avatar_${Date.now()}`);
+
+      const res = await fetch('/api/files/upload', { method: 'POST', body: formData });
+      if (!res.ok) throw new Error('Upload failed');
+      const json = await res.json();
+      const newUrl = json?.data?.url as string | undefined;
+      if (!newUrl) throw new Error('Missing file URL');
+
+      // Persist to user profile
+      await fetch('/api/user/update', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: user.$id, avatarUrl: newUrl }),
+      });
+
+      setAvatarUrl(newUrl);
+      toast({ title: 'Profile photo updated' });
+    } catch (e) {
+      toast({ title: 'Failed to update photo', variant: 'destructive' });
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleRemoveAvatar = async () => {
+    if (!user?.$id) return;
+    try {
+      setIsUploading(true);
+      await fetch('/api/user/update', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: user.$id, avatarUrl: '' }),
+      });
+      setAvatarUrl(undefined);
+      toast({ title: 'Profile photo removed' });
+    } catch {
+      toast({ title: 'Failed to remove photo', variant: 'destructive' });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
   return (
     <div className="flex gap-4">
       <QuickActions user={user} />
@@ -70,6 +139,41 @@ const DashboardHeader = ({ user }: DashboardHeaderProps) => {
           {/* Action buttons */}
           {user && (
             <div className="flex items-center space-x-2">
+              {/* Profile avatar */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="relative flex items-center justify-center rounded-full overflow-hidden w-8 h-8 border border-white/60 bg-white/70 hover:bg-white/90 transition-colors"
+                    aria-label="Profile menu"
+                    disabled={isUploading}
+                  >
+                    {avatarUrl && avatarUrl !== avatarPlaceholderUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={avatarUrl} alt="Profile" className="w-full h-full object-cover" />
+                    ) : (
+                      <Avatar name={user.name || (user as any)?.fullName} userId={user.email} size="sm" />
+                    )}
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem onClick={openFilePicker} className="flex items-center gap-2">
+                    <ImageIcon className="w-4 h-4" />
+                    {isUploading ? 'Uploading…' : 'Upload photo'}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleRemoveAvatar} className="flex items-center gap-2">
+                    <Trash2 className="w-4 h-4" />
+                    Remove photo
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="hidden"
+              />
               <Button
                 variant="ghost"
                 onClick={() => setNotifOpen(true)}

--- a/src/lib/actions/user.actions.ts
+++ b/src/lib/actions/user.actions.ts
@@ -1296,11 +1296,13 @@ export const updateUserProfile = async ({
   fullName,
   division,
   role,
+  avatarUrl,
 }: {
   accountId: string;
   fullName?: string;
   division?: UserDivision;
   role?: string;
+  avatarUrl?: string; // if empty string, clears avatar
 }) => {
   try {
     const { tablesDB } = await createAdminClient();
@@ -1322,7 +1324,10 @@ export const updateUserProfile = async ({
       databaseId: appwriteConfig.databaseId || 'default-db',
       tableId: appwriteConfig.usersCollectionId || 'users',
       rowId: userDoc.$id,
-      data: updatePayload,
+      data: {
+        ...updatePayload,
+        ...(avatarUrl !== undefined ? { avatar: avatarUrl } : {}),
+      },
     });
     return updatedUser;
   } catch (error) {


### PR DESCRIPTION
Add an editable profile picture to the DashboardHeader, allowing users to upload, remove, or display their initials as a fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf327b05-b626-4ddd-ac94-0283ce323892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf327b05-b626-4ddd-ac94-0283ce323892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

