### PR TITLE
Reconfigure admin dashboard layout

### DIFF
--- a/src/app/(root)/dashboard/AdminDashboard.tsx
+++ b/src/app/(root)/dashboard/AdminDashboard.tsx
@@ -141,9 +141,10 @@ const AdminDashboard = () => {
       </div>
 
       {/* Main Content Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* System Overview */}
-        <div className="lg:col-span-2">
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+        {/* Left Column */}
+        <div className="lg:col-span-8 space-y-6">
+          {/* System Overview */}
           <Card className="bg-white/30 backdrop-blur border border-white/40 shadow-lg">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
@@ -275,15 +276,15 @@ const AdminDashboard = () => {
               )}
             </CardContent>
           </Card>
-        </div>
 
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {/* Contract Expiry Alerts */}
-          <ContractExpiryAlertsWidget maxVisible={2} />
-          
           {/* Recent Activity */}
           <RecentActivity />
+        </div>
+
+        {/* Right Column */}
+        <div className="lg:col-span-4 space-y-6">
+          {/* Contract Expiry Alerts */}
+          <ContractExpiryAlertsWidget maxVisible={2} />
 
           {/* Quick Actions */}
           <Card className="bg-white/30 backdrop-blur border border-white/40 shadow-lg">


### PR DESCRIPTION
Reconfigure Admin dashboard card layout to fill empty space and utilize full width.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a2c75c2-10f4-4ca3-8627-2be4aeb9fc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a2c75c2-10f4-4ca3-8627-2be4aeb9fc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

