### PR TITLE
Fix landing page mobile UX and demo video loading

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1144,8 +1144,8 @@
 
 	/* Logo */
 	.logo {
-		/* Tailwind utilities */
-		@apply rounded-[10px] box-border w-min h-min flex flex-row justify-center items-center p-4 overflow-visible content-center flex-nowrap gap-[10px] absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] pointer-events-auto;
+		/* Tailwind utilities — keep below fixed header (z-50) */
+		@apply rounded-[10px] box-border w-min h-min flex flex-row justify-center items-center p-4 overflow-visible content-center flex-nowrap gap-[10px] absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-20 pointer-events-auto;
 	}
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,11 +15,23 @@ const NAV_LINKS = [
 	{ href: "#contact", label: "Contact", hideBelowXl: true },
 ] as const;
 
+const MOBILE_QUERY = "(max-width: 767px)";
+
 export const Header = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const headerRef = useRef(null);
 	const [scrolled, setScrolled] = useState(false);
+	// Mobile-first: assume narrow until matchMedia confirms desktop
+	const [isMobile, setIsMobile] = useState(true);
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia(MOBILE_QUERY);
+		const update = () => setIsMobile(mediaQuery.matches);
+		update();
+		mediaQuery.addEventListener("change", update);
+		return () => mediaQuery.removeEventListener("change", update);
+	}, []);
 
 	useEffect(() => {
 		const el = window;
@@ -42,27 +54,34 @@ export const Header = () => {
 	}, []);
 
 	const wrapperVariants = {
-		// At top of page: transparent + blur (original frosted glass bar)
-		// After scroll: compact frosted pill
+		// At top of page: transparent on desktop; frosted on mobile for contrast
+		// After scroll: compact frosted pill (full-width bar on mobile)
 		top: {
 			width: "100%",
 			height: 70,
 			borderRadius: 0,
 			marginTop: 0,
 			boxShadow: "none",
-			background: "rgba(255, 255, 255, 0)",
-			border: "1px solid rgba(255, 255, 255, 0)",
+			background: isMobile
+				? "rgba(255, 255, 255, 0.92)"
+				: "rgba(255, 255, 255, 0)",
+			border: isMobile
+				? "1px solid rgba(226, 232, 240, 0.8)"
+				: "1px solid rgba(255, 255, 255, 0)",
 			transition: { type: "spring" as const, stiffness: 260, damping: 28 },
 		},
 		scrolled: {
-			width: "min(920px, 88%)",
+			width: isMobile ? "100%" : "min(920px, 88%)",
 			height: 70,
-			borderRadius: 24,
-			marginTop: 16,
-			boxShadow:
-				"0 4px 32px 0 rgba(16,30,54,0.10), 0 1.5px 4px 0 rgba(16,30,54,0.03)",
-			background: "rgba(255,255,255,0.85)",
-			border: "1px solid rgba(200,200,200,0.18)",
+			borderRadius: isMobile ? 0 : 24,
+			marginTop: isMobile ? 0 : 16,
+			boxShadow: isMobile
+				? "0 1px 0 0 rgba(15, 23, 42, 0.06)"
+				: "0 4px 32px 0 rgba(16,30,54,0.10), 0 1.5px 4px 0 rgba(16,30,54,0.03)",
+			background: "rgba(255,255,255,0.94)",
+			border: isMobile
+				? "1px solid rgba(226, 232, 240, 0.9)"
+				: "1px solid rgba(200,200,200,0.18)",
 			transition: { type: "spring" as const, stiffness: 260, damping: 28 },
 		},
 	};
@@ -87,8 +106,9 @@ export const Header = () => {
 				left: 0,
 				right: 0,
 				zIndex: 50,
-				background: "rgba(255, 255, 255, 0)",
+				background: isMobile ? "rgba(255, 255, 255, 0.92)" : "rgba(255, 255, 255, 0)",
 			}}
+			className="max-md:backdrop-blur-md"
 		>
 			<motion.div
 				variants={wrapperVariants}
@@ -190,7 +210,7 @@ export const Header = () => {
 					></div>
 					<div
 						ref={menuRef}
-						className="fixed top-16 left-0 right-0 z-20 md:hidden py-6 border-t border-border bg-white w-full px-6 shadow-xl animate-fadeIn"
+						className="fixed top-[70px] left-0 right-0 z-20 md:hidden py-6 border-t border-border bg-white w-full px-6 shadow-xl animate-fadeIn"
 					>
 						<nav className="flex flex-col space-y-4 text-sm">
 							{NAV_LINKS.map((link) => (
@@ -204,6 +224,14 @@ export const Header = () => {
 								</a>
 							))}
 							<div className="flex flex-col space-y-2 pt-3">
+								<a href="#contact" onClick={() => setIsOpen(false)}>
+									<Button
+										variant="outline"
+										className="justify-start w-full rounded-full border-slate-300 text-slate-700 cursor-pointer"
+									>
+										Contact Sales
+									</Button>
+								</a>
 								<Link href="/sign-in">
 									<Button
 										variant="ghost"

--- a/src/components/SectionDivider.tsx
+++ b/src/components/SectionDivider.tsx
@@ -4,17 +4,19 @@ export default function SectionDivider() {
 	return (
 		<div className="w-full z-50">
 			<div className="container mx-auto px-4">
-				<div className="flex items-center gap-6">
+				<div className="flex items-center gap-3 sm:gap-6">
 					<div
-						className="h-px flex-1 border-t border-dashed border-slate-300/70"
+						className="hidden sm:block h-px flex-1 border-t border-dashed border-slate-300/70"
 						style={{ borderTopWidth: 1 }}
+						aria-hidden
 					/>
-					<p className="text-slate-700 text-sm md:text-base text-center whitespace-nowrap">
+					<p className="text-slate-700 text-sm md:text-base text-center text-pretty max-w-[20rem] sm:max-w-none mx-auto sm:mx-0">
 						Adopted by renowned, trusted, and leading enterprises
 					</p>
 					<div
-						className="h-px flex-1 border-t border-dashed border-slate-300/70"
+						className="hidden sm:block h-px flex-1 border-t border-dashed border-slate-300/70"
 						style={{ borderTopWidth: 1 }}
+						aria-hidden
 					/>
 				</div>
 			</div>

--- a/src/components/landing/AboutMission.tsx
+++ b/src/components/landing/AboutMission.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { Building2 } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import LandingFrostedCard from "./LandingFrostedCard";
 import LandingSection from "./LandingSection";
@@ -44,10 +45,15 @@ export default function AboutMission() {
 
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
 					<motion.div variants={fadeLeft} className="relative">
-						<div
-							className="relative rounded-2xl shadow-xl border border-white/60 w-full aspect-[560/420] bg-transparent"
-							aria-hidden
-						/>
+						<div className="relative overflow-hidden rounded-2xl shadow-xl border border-white/60 w-full aspect-[560/420] bg-slate-100">
+							<Image
+								src="/assets/video/demo-screenshots/01-dashboard-full.png"
+								alt="CAALM dashboard showing contracts, licenses, and compliance overview"
+								fill
+								className="object-cover object-top"
+								sizes="(max-width: 1023px) 100vw, 560px"
+							/>
+						</div>
 					</motion.div>
 
 					<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/components/landing/FeatureSpotlightGrid.tsx
+++ b/src/components/landing/FeatureSpotlightGrid.tsx
@@ -951,7 +951,7 @@ export default function FeatureSpotlightGrid() {
 			initial="hidden"
 			whileInView="visible"
 			viewport={viewportOnce}
-			id="features"
+			id="feature-spotlight"
 		>
 			<motion.div variants={fadeUp} className="text-center mb-8">
 				<h3 className="text-xl sm:text-2xl md:text-3xl sidebar-gradient-text landing-section-title">

--- a/src/components/landing/LandingHero.tsx
+++ b/src/components/landing/LandingHero.tsx
@@ -15,7 +15,12 @@ import PillSwing3D from "./PillSwing3D";
 import ShimmerBadge from "./ShimmerBadge";
 
 const VIDEO_SRC = "/assets/video/wave.mp4";
-const DEMO_VIDEO_SRC = "/assets/video/demo-landing.mp4";
+/** Full-quality desktop demo (~25MB / ~18Mbps) — dual soft-loop only above lg */
+const DEMO_VIDEO_DESKTOP_SRC = "/assets/video/demo-landing.mp4";
+/** Mobile-friendly encode (~5.4MB / ~3Mbps) — single player below lg */
+const DEMO_VIDEO_MOBILE_SRC = "/assets/video/caalm-demo-15s.mp4";
+const DEMO_POSTER_SRC = "/assets/video/demo-screenshots/06-landing-hero.png";
+const NARROW_QUERY = "(max-width: 1023px)";
 
 /** Crossfade lines under the hero H1 — previous copy + current block */
 const HERO_CROSSFADE_LINES = [
@@ -451,6 +456,21 @@ function safePlay(video: HTMLVideoElement | null) {
 	}
 }
 
+function useIsNarrow(query = NARROW_QUERY) {
+	// Mobile-first default avoids briefly requesting the 25MB desktop encode
+	const [matches, setMatches] = useState(true);
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia(query);
+		const update = () => setMatches(mediaQuery.matches);
+		update();
+		mediaQuery.addEventListener("change", update);
+		return () => mediaQuery.removeEventListener("change", update);
+	}, [query]);
+
+	return matches;
+}
+
 function useAutoplayLoopVideo(
 	videoRef: RefObject<HTMLVideoElement | null>,
 	reduceMotion: boolean | null,
@@ -641,6 +661,7 @@ function LogoMarquee() {
 
 export default function LandingHero() {
 	const reduceMotion = useReducedMotion();
+	const isNarrow = useIsNarrow();
 	const videoRef = useRef<HTMLVideoElement | null>(null);
 	const demoVideoPrimaryRef = useRef<HTMLVideoElement | null>(null);
 	const demoVideoSecondaryRef = useRef<HTMLVideoElement | null>(null);
@@ -649,7 +670,11 @@ export default function LandingHero() {
 	const [demoInView, setDemoInView] = useState(false);
 	const [demoShouldLoad, setDemoShouldLoad] = useState(false);
 	const [demoLoaded, setDemoLoaded] = useState(false);
+	const [demoFailed, setDemoFailed] = useState(false);
 	const [demoActiveLayer, setDemoActiveLayer] = useState<0 | 1>(0);
+
+	const demoSrc = isNarrow ? DEMO_VIDEO_MOBILE_SRC : DEMO_VIDEO_DESKTOP_SRC;
+	const useSoftCrossfade = !isNarrow && !reduceMotion;
 
 	useEffect(() => {
 		if (reduceMotion) return;
@@ -669,21 +694,33 @@ export default function LandingHero() {
 				setDemoInView(visible);
 				if (visible) setDemoShouldLoad(true);
 			},
-			{ rootMargin: "120px 0px", threshold: 0.2 },
+			{ rootMargin: "240px 0px", threshold: 0.05 },
 		);
 
 		observer.observe(frame);
 		return () => observer.disconnect();
 	}, []);
 
+	// Reset load state when swapping mobile/desktop sources
+	useEffect(() => {
+		setDemoLoaded(false);
+		setDemoFailed(false);
+		setDemoActiveLayer(0);
+	}, [demoSrc]);
+
 	useAutoplayLoopVideo(videoRef, reduceMotion);
+	useAutoplayLoopVideo(
+		demoVideoPrimaryRef,
+		reduceMotion,
+		demoInView && demoShouldLoad && demoLoaded && !useSoftCrossfade,
+	);
 	useSoftLoopCrossfade(
 		demoVideoPrimaryRef,
 		demoVideoSecondaryRef,
 		demoActiveLayer,
 		setDemoActiveLayer,
 		reduceMotion,
-		demoInView && demoShouldLoad && demoLoaded,
+		demoInView && demoShouldLoad && demoLoaded && useSoftCrossfade,
 	);
 
 	useEffect(() => {
@@ -702,6 +739,14 @@ export default function LandingHero() {
 		}
 	}, [reduceMotion]);
 
+	const handleDemoTapToPlay = () => {
+		setDemoFailed(false);
+		setDemoShouldLoad(true);
+		const video = demoVideoPrimaryRef.current;
+		if (!video) return;
+		safePlay(video);
+	};
+
 	return (
 		<section className="relative flex flex-col items-center justify-center pt-24 pb-16 overflow-hidden">
 			{!reduceMotion ? (
@@ -712,7 +757,7 @@ export default function LandingHero() {
 					muted
 					loop
 					playsInline
-					preload="auto"
+					preload="metadata"
 					onEnded={(e) => {
 						const video = e.currentTarget;
 						video.currentTime = 0;
@@ -741,14 +786,14 @@ export default function LandingHero() {
 			</div>
 
 			{/* Logo — reserve height; .logo is absolute and would otherwise collapse layout */}
-			<div className="relative z-20 w-full mb-12 md:mt-4">
+			<div className="relative z-20 w-full mb-8 md:mb-12 md:mt-4">
 				<div className="relative mx-auto h-[140px] w-[140px]">
 					<Logo />
 				</div>
 			</div>
 
 			{/* Intro tagline — separate flow block below logo */}
-			<div className="relative z-20 w-full px-4 sm:px-6 mb-12 md:mb-16">
+			<div className="relative z-20 w-full px-4 sm:px-6 mb-8 md:mb-16">
 				<motion.div
 					className="mx-auto max-w-4xl text-center"
 					variants={staggerContainer}
@@ -773,9 +818,10 @@ export default function LandingHero() {
 			</div>
 
 			<div className="w-full px-4 sm:px-6 lg:px-8 xl:px-12 relative z-20">
-				<div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12 items-start">
+				<div className="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-start">
+					{/* Copy + CTAs — first on all breakpoints */}
 					<motion.div
-						className="flex flex-col gap-4"
+						className="order-1 flex flex-col gap-4"
 						variants={staggerContainer}
 						initial="hidden"
 						animate="visible"
@@ -873,104 +919,148 @@ export default function LandingHero() {
 							<span className="text-slate-700 font-semibold text-sm">5/5</span>
 							<span className="text-slate-500 text-sm">based on reviews</span>
 						</motion.div>
-
-						<motion.div
-							variants={fadeUp}
-							className="mt-4 max-w-md mx-auto lg:mx-0 rounded-xl bg-white/80 p-4 shadow-[0_1px_2px_0_rgba(15,23,42,0.06)]"
-						>
-							<p className="text-slate-800 text-base italic">
-								&ldquo;I use CAALM every day to keep all our contracts and
-								compliance documents organized. It&rsquo;s so helpful, our team
-								never misses a deadline or audit anymore!&rdquo;
-							</p>
-							<div className="mt-2 flex items-center gap-2">
-								<Image
-									src="/assets/images/review-avatar.jpg"
-									alt="Priya Sharma"
-									width={32}
-									height={32}
-									className="h-8 w-8 rounded-full"
-									loading="lazy"
-									sizes="32px"
-								/>
-								<div>
-									<p className="text-sm font-semibold text-slate-800">
-										Priya Sharma
-									</p>
-									<p className="text-xs text-slate-500">
-										Director of Human Resources at Growthspark
-									</p>
-								</div>
-							</div>
-						</motion.div>
 					</motion.div>
 
+					{/* Demo — directly after CTAs on mobile; right column on desktop */}
 					<motion.div
-						className="relative w-full flex flex-col gap-5 lg:gap-6"
+						className="order-2 relative w-full flex flex-col gap-5 lg:gap-6 lg:row-span-2"
 						initial={reduceMotion ? false : { opacity: 0, y: 32 }}
 						animate={{ opacity: 1, y: 0 }}
 						transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
 					>
 						<div
 							ref={demoFrameRef}
-							className="relative w-full aspect-video overflow-hidden rounded-lg border border-white/70 bg-white/60 shadow-[0_12px_40px_rgba(15,23,42,0.18)] backdrop-blur-md"
+							className="relative w-full aspect-video overflow-hidden rounded-lg border border-white/70 bg-slate-100 shadow-[0_12px_40px_rgba(15,23,42,0.18)]"
 						>
-							{!demoLoaded && (
+							<Image
+								src={DEMO_POSTER_SRC}
+								alt=""
+								fill
+								priority
+								sizes="(max-width: 1023px) 100vw, 560px"
+								className={`object-cover object-center transition-opacity duration-300 ${
+									demoLoaded && !reduceMotion ? "opacity-0" : "opacity-100"
+								}`}
+								aria-hidden
+							/>
+
+							{!demoLoaded && !reduceMotion && (
 								<div
 									aria-hidden
-									className="absolute inset-0 z-10 animate-pulse bg-linear-to-br from-slate-200/80 via-slate-100/70 to-slate-200/80"
+									className="absolute inset-0 z-[1] animate-pulse bg-gradient-to-br from-slate-200/50 via-transparent to-slate-200/40"
 								/>
 							)}
-							{demoShouldLoad && (
+
+							{!reduceMotion && demoShouldLoad && (
 								<>
 									<video
 										ref={demoVideoPrimaryRef}
-										src={DEMO_VIDEO_SRC}
+										src={demoSrc}
 										muted
 										playsInline
-										preload="auto"
-										autoPlay={!reduceMotion && demoInView}
-										onLoadedData={() => setDemoLoaded(true)}
-										className={`absolute inset-0 h-full w-full object-contain object-center brightness-[1.09] contrast-[1.04] transition-opacity ease-in-out ${
-											demoLoaded && demoActiveLayer === 0
+										preload={isNarrow ? "metadata" : "auto"}
+										autoPlay={demoInView}
+										poster={DEMO_POSTER_SRC}
+										onLoadedData={() => {
+											setDemoLoaded(true);
+											setDemoFailed(false);
+										}}
+										onError={() => setDemoFailed(true)}
+										className={`absolute inset-0 z-[2] h-full w-full object-contain object-center brightness-[1.09] contrast-[1.04] transition-opacity ease-in-out ${
+											demoLoaded && (!useSoftCrossfade || demoActiveLayer === 0)
 												? "opacity-100"
 												: "opacity-0"
 										}`}
 										style={{ transitionDuration: `${DEMO_LOOP_FADE_MS}ms` }}
 										aria-label="CAALM product demo"
 									/>
-									<video
-										ref={demoVideoSecondaryRef}
-										src={DEMO_VIDEO_SRC}
-										muted
-										playsInline
-										preload="auto"
-										className={`absolute inset-0 h-full w-full object-contain object-center brightness-[1.09] contrast-[1.04] transition-opacity ease-in-out ${
-											demoLoaded && demoActiveLayer === 1
-												? "opacity-100"
-												: "opacity-0"
-										}`}
-										style={{ transitionDuration: `${DEMO_LOOP_FADE_MS}ms` }}
-										aria-hidden
-									/>
+									{useSoftCrossfade ? (
+										<video
+											ref={demoVideoSecondaryRef}
+											src={demoSrc}
+											muted
+											playsInline
+											preload="auto"
+											className={`absolute inset-0 z-[2] h-full w-full object-contain object-center brightness-[1.09] contrast-[1.04] transition-opacity ease-in-out ${
+												demoLoaded && demoActiveLayer === 1
+													? "opacity-100"
+													: "opacity-0"
+											}`}
+											style={{ transitionDuration: `${DEMO_LOOP_FADE_MS}ms` }}
+											aria-hidden
+										/>
+									) : null}
 								</>
+							)}
+
+							{demoFailed && (
+								<button
+									type="button"
+									onClick={handleDemoTapToPlay}
+									className="absolute inset-0 z-[3] flex items-center justify-center bg-slate-900/25 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0f5384]/40"
+									aria-label="Play product demo"
+								>
+									<span className="rounded-full bg-white/95 px-4 py-2 text-sm font-semibold text-slate-800 shadow-md">
+										Tap to play demo
+									</span>
+								</button>
 							)}
 						</div>
 
-						<div className="grid grid-cols-3 gap-3 sm:gap-4 w-full">
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-4 w-full">
 							{HERO_TRUST_PILLARS.map((pillar) => (
-								<article key={pillar.id} className="flex min-w-0 flex-col">
-									<div className="mb-3 h-24 sm:h-28 md:h-32 w-full">
-										<pillar.Visual animate={!reduceMotion} />
+								<article
+									key={pillar.id}
+									className="flex min-w-0 flex-col sm:flex-col gap-3 sm:gap-0 rounded-xl border border-slate-200/70 bg-white/70 p-3 sm:p-0 sm:border-0 sm:bg-transparent"
+								>
+									<div className="flex sm:block items-start gap-3">
+										<div className="mb-0 sm:mb-3 h-20 w-28 shrink-0 sm:h-28 md:h-32 sm:w-full">
+											<pillar.Visual animate={!reduceMotion} />
+										</div>
+										<div className="min-w-0 flex-1">
+											<h3 className="text-sm font-semibold leading-snug sidebar-gradient-text">
+												{pillar.title}
+											</h3>
+											<p className="mt-1 text-xs sm:text-xs leading-snug text-slate-600 sm:line-clamp-3">
+												{pillar.description}
+											</p>
+										</div>
 									</div>
-									<h3 className="text-xs sm:text-sm font-semibold leading-snug sidebar-gradient-text">
-										{pillar.title}
-									</h3>
-									<p className="mt-1 text-[11px] sm:text-xs leading-snug text-slate-600 line-clamp-3">
-										{pillar.description}
-									</p>
 								</article>
 							))}
+						</div>
+					</motion.div>
+
+					{/* Quote — after demo on mobile; under copy on desktop */}
+					<motion.div
+						variants={fadeUp}
+						initial="hidden"
+						animate="visible"
+						className="order-3 mt-0 max-w-md mx-auto lg:mx-0 rounded-xl bg-white/80 p-4 shadow-[0_1px_2px_0_rgba(15,23,42,0.06)] w-full"
+					>
+						<p className="text-slate-800 text-base italic">
+							&ldquo;I use CAALM every day to keep all our contracts and
+							compliance documents organized. It&rsquo;s so helpful, our team
+							never misses a deadline or audit anymore!&rdquo;
+						</p>
+						<div className="mt-2 flex items-center gap-2">
+							<Image
+								src="/assets/images/review-avatar.jpg"
+								alt="Priya Sharma"
+								width={32}
+								height={32}
+								className="h-8 w-8 rounded-full"
+								loading="lazy"
+								sizes="32px"
+							/>
+							<div>
+								<p className="text-sm font-semibold text-slate-800">
+									Priya Sharma
+								</p>
+								<p className="text-xs text-slate-500">
+									Director of Human Resources at Growthspark
+								</p>
+							</div>
 						</div>
 					</motion.div>
 				</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On mobile, the hero demo often looked blank (especially on cellular). Trust pillars stayed cramped in 3 columns, the “Adopted by…” line overflowed, the fixed header covered content, `#features` was duplicated, About had an empty media box, and the hamburger menu was missing Contact Sales.

## Root cause (demo)
`demo-landing.mp4` is ~25MB / ~18Mbps and was loaded twice with `preload="auto"`. Videos stayed at `opacity: 0` until `onLoadedData`, so Slow 3G left a grey pulse forever.

## Fix
- Below `lg`: single player + `caalm-demo-15s.mp4` (~5.4MB), poster shown immediately, `preload="metadata"`
- Desktop: keep dual soft-loop with full `demo-landing.mp4`
- Move demo above the quote on mobile; stack trust pillars to 1 column
- Wrap SectionDivider text; frost mobile header; lower `.logo` z-index
- Rename spotlight id to `#feature-spotlight`; add About dashboard image; add Contact Sales to mobile menu

## Verify
1. Open `/` at 390px width (hamburger visible)
2. Confirm poster shows in the demo frame before/while loading
3. Throttle to Slow 3G — demo should still show poster, then play `caalm-demo-15s.mp4` (not the 25MB file)
4. Trust pillars stack full-width; “Adopted by…” wraps; menu includes Contact Sales
5. Desktop still uses dual `demo-landing.mp4` soft-loop

[Mobile demo on Slow 3G with poster](https://cursor.com/agents/bc-b22d365f-d461-4cf4-9052-d3b07de4da4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fverify-slow3g-poster.png)
[Mobile demo playing after load](https://cursor.com/agents/bc-b22d365f-d461-4cf4-9052-d3b07de4da4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fverify-fast-demo.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b22d365f-d461-4cf4-9052-d3b07de4da4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b22d365f-d461-4cf4-9052-d3b07de4da4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

